### PR TITLE
Properly set the default uncompressed data size for older chunk versions

### DIFF
--- a/src/EpicManifestParser/UE/FChunkHeader.cs
+++ b/src/EpicManifestParser/UE/FChunkHeader.cs
@@ -25,7 +25,7 @@ internal struct FChunkHeader
 	/// <summary>
 	/// The size of this data uncompressed.
 	/// </summary>
-	public int32 DataSizeUncompressed = 1024 * 1024; // 1 MB is the default for all versions that do not store this explicitly
+	public int32 DataSizeUncompressed;
 	/// <summary>
 	/// How the chunk data is stored.
 	/// </summary>
@@ -63,6 +63,7 @@ internal struct FChunkHeader
 			//RollingHash = reader.Read<uint64>();
 			reader.Position += FGuid.Size + sizeof(uint64);
 			StoredAs = reader.Read<EChunkStorageFlags>();
+			DataSizeUncompressed = 1024 * 1024;
 
 			if (Version >= EChunkVersion.StoresShaAndHashType)
 			{

--- a/src/EpicManifestParser/UE/FChunkHeader.cs
+++ b/src/EpicManifestParser/UE/FChunkHeader.cs
@@ -25,7 +25,7 @@ internal struct FChunkHeader
 	/// <summary>
 	/// The size of this data uncompressed.
 	/// </summary>
-	public int32 DataSizeUncompressed;
+	public int32 DataSizeUncompressed = 1024 * 1024; // 1 MB is the default for all versions that do not store this explicitly
 	/// <summary>
 	/// How the chunk data is stored.
 	/// </summary>
@@ -81,10 +81,6 @@ internal struct FChunkHeader
 					{
 						DataSizeUncompressed = reader.Read<int32>();
 					}
-				}
-				else
-				{
-					DataSizeUncompressed = 1048576; // The default for all older versions is 1MB.
 				}
 			}
 		}

--- a/src/EpicManifestParser/UE/FChunkHeader.cs
+++ b/src/EpicManifestParser/UE/FChunkHeader.cs
@@ -1,4 +1,4 @@
-﻿using GenericReader;
+using GenericReader;
 
 namespace EpicManifestParser.UE;
 
@@ -82,6 +82,10 @@ internal struct FChunkHeader
 						DataSizeUncompressed = reader.Read<int32>();
 					}
 				}
+                else
+                {
+                    DataSizeUncompressed = 1048576; // The default for all older versions is 1MB.
+                }
 			}
 		}
 

--- a/src/EpicManifestParser/UE/FChunkHeader.cs
+++ b/src/EpicManifestParser/UE/FChunkHeader.cs
@@ -82,10 +82,10 @@ internal struct FChunkHeader
 						DataSizeUncompressed = reader.Read<int32>();
 					}
 				}
-                else
-                {
-                    DataSizeUncompressed = 1048576; // The default for all older versions is 1MB.
-                }
+				else
+				{
+					DataSizeUncompressed = 1048576; // The default for all older versions is 1MB.
+				}
 			}
 		}
 


### PR DESCRIPTION
Currently this just leaves DataSizeUncompressed initialized to 0, which breaks subsequent decompression.
Source: https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Online/BuildPatchServices/Private/Data/ChunkData.cpp#L201