### PR TITLE
Bump AsyncKeyedLock to 8.0.2, clean up lock.

### DIFF
--- a/src/EpicManifestParser/EpicManifestParser.csproj
+++ b/src/EpicManifestParser/EpicManifestParser.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="8.0.0" />
+    <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
     <PackageReference Include="Flurl" Version="4.0.0" />
     <PackageReference Include="GenericReader" Version="2.2.0" />
     <PackageReference Include="OffiUtils" Version="2.0.1" />

--- a/src/EpicManifestParser/EpicManifestParser.csproj
+++ b/src/EpicManifestParser/EpicManifestParser.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
+    <PackageReference Include="AsyncKeyedLock" Version="8.0.0" />
     <PackageReference Include="Flurl" Version="4.0.0" />
     <PackageReference Include="GenericReader" Version="2.2.0" />
     <PackageReference Include="OffiUtils" Version="2.0.1" />

--- a/src/EpicManifestParser/EpicManifestParser.csproj
+++ b/src/EpicManifestParser/EpicManifestParser.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="7.1.4" />
+    <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
     <PackageReference Include="Flurl" Version="4.0.0" />
     <PackageReference Include="GenericReader" Version="2.2.0" />
     <PackageReference Include="OffiUtils" Version="2.0.1" />

--- a/src/EpicManifestParser/FFileManifestStream.cs
+++ b/src/EpicManifestParser/FFileManifestStream.cs
@@ -561,7 +561,7 @@ internal sealed class DownloadState<TDestination> : IEnumerable<ChunkWithOffset<
 	public readonly TDestination Destination;
 	public readonly FFileManifest FileManifest;
 
-	private readonly LockObject? _lock;
+	private readonly LockObject _lock = new();
 	private readonly object? _userState;
 	private readonly Action<SaveProgressChangedEventArgs>? _callback;
 	private readonly long _totalBytesToSave;
@@ -580,7 +580,6 @@ internal sealed class DownloadState<TDestination> : IEnumerable<ChunkWithOffset<
 		FileManifest = fileManifest;
 
 		if (callback is null) return;
-		_lock = new LockObject();
 		_userState = userState;
 		_callback = callback;
 		_totalBytesToSave = totalBytesToSave;
@@ -591,7 +590,7 @@ internal sealed class DownloadState<TDestination> : IEnumerable<ChunkWithOffset<
 		if (_callback is null)
 			return;
 
-		lock (_lock!)
+		lock (_lock)
 		{
 			_bytesSaved += amount;
 			var progress = (int)MathF.Truncate((float)_bytesSaved / _totalBytesToSave * 100f);


### PR DESCRIPTION
I also wanted to comment on how the locker options may be suboptimal, especially that PoolInitialFill value. 64 means you are sure you will have a minimum of 64 concurrent threads with distinct FGuid values, so you want to create them immediately on startup so they're already allocated.

The standard settings I like working with (also set as the default values) are 20 for the pool size and 1 for the pool initial fill. Please note that the 20 doesn't mean a hard rate limit of 20 concurrent threads. If a 21st one comes along, the pool would be empty and a SemaphoreSlim object is created just as if there was no pooling involved.